### PR TITLE
Add Playwright test for EPAM Client Work

### DIFF
--- a/tests/epam_client_work.spec.ts
+++ b/tests/epam_client_work.spec.ts
@@ -1,0 +1,15 @@
+import { test, expect } from '@playwright/test';
+
+test('EPAM Client Work Test', async ({ page }) => {
+  // Navigate to the EPAM website
+  await page.goto('https://www.epam.com/');
+
+  // Click on "Services" from the header menu
+  await page.getByRole('link', { name: 'Services', exact: true }).click();
+
+  // Click on "Explore Our Client Work"
+  await page.getByText('Explore Our Client Work').nth(1).click();
+
+  // Verify that the "Client Work" text is visible on the page
+  await expect(page.getByText('Client Work')).toBeVisible();
+});


### PR DESCRIPTION
This pull request adds a Playwright test to verify the navigation and visibility of the 'Client Work' section on the EPAM website. The test performs the following steps:

1. Navigates to the EPAM website.
2. Selects 'Services' from the header menu.
3. Clicks the 'Explore Our Client Work' link.
4. Verifies that the 'Client Work' text is visible on the page.